### PR TITLE
Typo at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Parse google merchant feed to array  PHP
 ## Installation
 
 ```
-composer required silici0/googleparserfeed:dev-master
+composer require silici0/googleparserfeed:dev-master
 ```
 
 


### PR DESCRIPTION
There are a typo at the installation instructions.

I made this simple PR to fix that =)