### PR TITLE
toArray() throw on encoding error

### DIFF
--- a/src/ParserGoogleFeed.php
+++ b/src/ParserGoogleFeed.php
@@ -49,6 +49,7 @@ class ParserGoogleFeed extends SimpleXMLElement implements JsonSerializable
     }
 
     public function toArray() {
-        return (array) json_decode(json_encode($this));
+        $flags = (PHP_VERSION_ID >= 70300 ? JSON_THROW_ON_ERROR : 0);
+        return (array) json_decode(json_encode($this, false, 999, $flags), $flags);
     }
 }


### PR DESCRIPTION
if some of the data can not be encoded to/from json for some reason, throw.

begs the question, is it possible to encode data in XML that cannot be legally encoded to JSON?  i  don't know, but with this, if it happens, we'll get an JsonException instead of false.

- if PHP <= 7.2 is no longer supported, the PHP_VERSION_ID check can be removed.
(my personal opinion is that supporting anything older than PHP7.4 isn't worthwhile, fwiw)