### PR TITLE
fix PHP>=8.1 E_DEPRECATED

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
             "email": "silici0@gmail.com"
         }
     ],
+    "require": {
+        "php": ">=7.1"
+    },
     "autoload": {
         "psr-4": {
             "silici0\\GoogleParserFeed\\" : "src/"

--- a/src/ParserGoogleFeed.php
+++ b/src/ParserGoogleFeed.php
@@ -5,8 +5,7 @@ use JsonSerializable;
 
 class ParserGoogleFeed extends SimpleXMLElement implements JsonSerializable 
 {
-
-    public function jsonSerialize()
+    public function jsonSerialize(): ?array
     {
         $array = array();
 


### PR DESCRIPTION
as of PHP8.1, this library generates the E_DEPRECATED 

>PHP Deprecated:  Return type of silici0\GoogleParserFeed\ParserGoogleFeed::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

fix that.

this patch breaks compatibility with anything older than PHP7.1 (eg 7.0 will no longer work, as 7.0 doesn't support `?array` )